### PR TITLE
Enable CORS for the referrer of any HTTP request

### DIFF
--- a/templates/kubernetes/deploy/ingress.yml
+++ b/templates/kubernetes/deploy/ingress.yml
@@ -10,8 +10,68 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: clusterissuer-letsencrypt-production
     # CORS
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "<% .Name %>.<% index .Params `frontendSubdomain` %>.<% index .Params `domain` %>"
+    ######################################################################################################################
+    # This snippet automatically enables CORS for the referrer of any HTTP request. 
+    # It is here to simplify CORS headaches for Playground apps only and is *NOT* to be used in a real production setting.
+    # Snippet copied from https://qa.lsproc.com/post/access-control-allow-origin-multiple-origin-domains.
+    ######################################################################################################################
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+        add_header 'Access-Control-Allow-Origin' "$http_origin";
+        if ($http_origin ~* (^https?://([^/]+\.)*)) {
+            set $cors "true";
+        }
+        # Determine the HTTP request method used
+        if ($request_method = 'OPTIONS') {
+            set $cors "${cors}options";
+        }
+        if ($request_method = 'GET') {
+            set $cors "${cors}get";
+        }
+        if ($request_method = 'POST') {
+            set $cors "${cors}post";
+        }
+
+        if ($cors = "true") {
+            # Catch all incase there's a request method we're not dealing with properly
+            add_header 'Access-Control-Allow-Origin' "$http_origin";
+        }
+
+        if ($cors = "trueget") {
+            add_header 'Access-Control-Allow-Origin' "$http_origin";
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+        }
+
+        if ($cors = "trueoptions") {
+            add_header 'Access-Control-Allow-Origin' "$http_origin";
+
+            #
+            # Allow cookies to be sent with requests
+            #
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+
+            #
+            # Custom headers and headers various browsers *should* be OK with but aren't
+            #
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+
+            #
+            # Tell client that this pre-flight info is valid for 20 days
+            #
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+
+        if ($cors = "truepost") {
+            add_header 'Access-Control-Allow-Origin' "$http_origin";
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+        }
 
 spec:
   rules:

--- a/templates/kubernetes/deploy/ingress.yml
+++ b/templates/kubernetes/deploy/ingress.yml
@@ -13,65 +13,13 @@ metadata:
     ######################################################################################################################
     # This snippet automatically enables CORS for the referrer of any HTTP request. 
     # It is here to simplify CORS headaches for Playground apps only and is *NOT* to be used in a real production setting.
-    # Snippet copied from https://qa.lsproc.com/post/access-control-allow-origin-multiple-origin-domains.
+    # Snippet based off https://qa.lsproc.com/post/access-control-allow-origin-multiple-origin-domains.
     ######################################################################################################################
     nginx.ingress.kubernetes.io/configuration-snippet: |
         add_header 'Access-Control-Allow-Origin' "$http_origin";
-        if ($http_origin ~* (^https?://([^/]+\.)*)) {
-            set $cors "true";
-        }
-        # Determine the HTTP request method used
-        if ($request_method = 'OPTIONS') {
-            set $cors "${cors}options";
-        }
-        if ($request_method = 'GET') {
-            set $cors "${cors}get";
-        }
-        if ($request_method = 'POST') {
-            set $cors "${cors}post";
-        }
-
-        if ($cors = "true") {
-            # Catch all incase there's a request method we're not dealing with properly
-            add_header 'Access-Control-Allow-Origin' "$http_origin";
-        }
-
-        if ($cors = "trueget") {
-            add_header 'Access-Control-Allow-Origin' "$http_origin";
-            add_header 'Access-Control-Allow-Credentials' 'true';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-        }
-
-        if ($cors = "trueoptions") {
-            add_header 'Access-Control-Allow-Origin' "$http_origin";
-
-            #
-            # Allow cookies to be sent with requests
-            #
-            add_header 'Access-Control-Allow-Credentials' 'true';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-
-            #
-            # Custom headers and headers various browsers *should* be OK with but aren't
-            #
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-
-            #
-            # Tell client that this pre-flight info is valid for 20 days
-            #
-            add_header 'Access-Control-Max-Age' 1728000;
-            add_header 'Content-Type' 'text/plain charset=UTF-8';
-            add_header 'Content-Length' 0;
-            return 204;
-        }
-
-        if ($cors = "truepost") {
-            add_header 'Access-Control-Allow-Origin' "$http_origin";
-            add_header 'Access-Control-Allow-Credentials' 'true';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-        }
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
 
 spec:
   rules:


### PR DESCRIPTION
This PR uses a configuration snippet to automatically enable CORS for the referrer of any HTTP request. This is primarily to simplify any CORS headaches from getting a Playground app up and running, e.g. a dev does not need to know their frontend domain in advance when creating the backend, or they could easily have multiple domains calling into their backend if need be.

Fixes https://github.com/commit-app-playground/backend-template/issues/4