### PR TITLE
Add support for application secrets with an example

### DIFF
--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -99,3 +99,4 @@ $RECYCLE.BIN/
 
 # application environment config
 .env
+secrets/secrets.yml

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,0 +1,3 @@
+# Creates (or updates) secrets object on the k8s cluster server
+upsert-secrets:
+	kubectl apply -n <% .Name %> -f secrets/secrets.yml

--- a/templates/README.md
+++ b/templates/README.md
@@ -22,6 +22,15 @@ To set up your local environment with access to AWS and Kubernetes, just run:
 ```
 This script will open a web browser and prompt you to log in with your Commit Gmail account, and then will configure an AWS profile and a Kubernetes context.
 
+# Creating secrets
+
+The Playground uses a somewhat "quick and dirty" way to create secrets for your application without needing to commit them to your GitHub repository. In order to add secrets to your deployment:
+
+1. Rename `secrets/secrets.yml.example` to `secrets.yml` (note that `secrets.yml` has been added to the `.gitignore` file, so they will not be committed to your GitHub repository).
+2. Add secrets to the `stringData` section of your `secrets.yml` file as appropriate. In your deployed application, each secret key will be available as an environment variable.
+3. Run `make upsert-secrets` from the root of your application which will create the secrets object on your Kubernetes cluster server.
+4. That's it! Deploy your application in order for the secrets to be picked up, and you should now be able to access them as environment variables via the defined secret keys.
+
 # Structure
 ## Kubernetes
 The configuration of your application in Kubernetes uses [https://kustomize.io/](kustomize) and is run by the CI pipeline, the configuration is in the [`/kubernetes`](./kubernetes/deploy/) directory.

--- a/templates/kubernetes/deploy/deployment.yml
+++ b/templates/kubernetes/deploy/deployment.yml
@@ -26,6 +26,10 @@ spec:
           envFrom:
           - configMapRef:
               name: <% .Name %>-config
+          # Uncomment the secretRef block below if your Playground application has secrets
+          # See the README for instructions on how to create secrets
+          #- secretRef:
+          #    name: <% .Name %>-secrets
           readinessProbe:
             httpGet:
               port: http

--- a/templates/secrets/secrets.yml.example
+++ b/templates/secrets/secrets.yml.example
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <% .Name %>-secrets
+type: Opaque
+stringData:
+  TEST_SECRET_KEY: test-secret-value


### PR DESCRIPTION
This PR attempts to simplify the process for a developer to add secrets to their Playground application.

Addresses https://github.com/commit-app-playground/backend-template/issues/6