### PR TITLE
Allow app name to be different than repository name

### DIFF
--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ env:
   accountId: ${{ secrets.AWS_ACCOUNT_ID }}
   repo: ${{ secrets.ECR_REPOSITORY }}
   cluster-name: ${{ secrets.EKS_CLUSTER_NAME }}
+  # Note that technically these would change per environment, but there is only one environment for the Playground anyway
+  APP_NAME: <% .Name %>
+  NAMESPACE: <% .Name %>
 jobs:
   unit-test:
     runs-on: ubuntu-latest
@@ -34,8 +37,7 @@ jobs:
         - uses: actions/checkout@v2
         - name: Set IMAGE_TAG as env
           run: |
-            APP_NAME=$(echo "${{ github.repository }}" | sed -e 's/.*\///g')
-            IMAGE_TAG=${APP_NAME}-$(git rev-parse --short=7 ${{ github.sha }})
+            IMAGE_TAG=${{ env.APP_NAME }}-$(git rev-parse --short=7 ${{ github.sha }})
             echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
         - if: env.AWS_ACCESS_KEY_ID == null
           run: |
@@ -67,15 +69,8 @@ jobs:
         - uses: actions/checkout@v2
         - name: Set IMAGE_TAG as env
           run: |
-            APP_NAME=$(echo "${{ github.repository }}" | sed -e 's/.*\///g')
-            IMAGE_TAG=${APP_NAME}-$(git rev-parse --short=7 ${{ github.sha }})
+            IMAGE_TAG=${{ env.APP_NAME }}-$(git rev-parse --short=7 ${{ github.sha }})
             echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
-        - name: Set APP_NAME and NAMESPACE as env
-          run: |
-            NAMESPACE=$(echo "${{ github.repository }}" | sed -e 's/.*\///g')
-            echo "NAMESPACE=${NAMESPACE}" >> $GITHUB_ENV
-            APP_NAME=$(echo "${{ github.repository }}" | sed -e 's/.*\///g')
-            echo "APP_NAME=${APP_NAME}" >> $GITHUB_ENV
         - name: Install kubectl
           uses: azure/setup-kubectl@v1
         - name: Configure AWS credentials

--- a/zero-project.yml
+++ b/zero-project.yml
@@ -8,6 +8,7 @@
 # Fill in the name of your app - this becomes the deployment/namespace/svc name in kubernetes.
 # Must be lowercase alphanumeric with dashes only and must be unique within the cluster.
 # Using the same name as this repository is probably a good idea.
+# If you absolutely must use a different name than the repository, double check that it is unique within the Playground first.
 name:
 
 shouldPushRepositories: false


### PR DESCRIPTION
This PR uses the app name from the template, rather than parsing out the GitHub repository name, in order to create the deployment/namespace/svc name in Kubernetes.

I validated this fix by creating a new backend project off the template from this branch, and verifying that the deploy succeeded / all the resources were created using the app name as expected. Test repo is here https://github.com/commit-app-playground/lucas-backend-test-0719-2, where the app name is `lucas-be-test-0719-2`.

Fixes https://github.com/commit-app-playground/backend-template/issues/5